### PR TITLE
fix: missing logger param in the verify code function

### DIFF
--- a/routes/auth.py
+++ b/routes/auth.py
@@ -146,7 +146,7 @@ async def verify_email(request: UserCompleteVerify, db: Session = Depends(get_db
         raise InternalServerError("Error updating user")
 
     # keep this doubled/consuming AFTER Firebase checks to avoid codes being expired by Firebase errors
-    verify_code(db, uid, request.code, purpose="verify", consume=True)  # verify & consume
+    verify_code(db, logger, uid, request.code, purpose="verify", consume=True)  # verify & consume
 
     logger.info(f"User {uid} successfully verified their email")
     return {"message": "Email verified successfully"}


### PR DESCRIPTION
Why:
- while trying to verify code, the `/api/auth/verify-email` will always error because I didn't put the correct params in the function call

Changes:
- Fix function call to `verify_code` to include `logger`