### PR TITLE
feat: Rate limiting

### DIFF
--- a/routes/auth.py
+++ b/routes/auth.py
@@ -122,7 +122,7 @@ async def delete_user_account(
     return {"message": "Account deleted successfully"}
 
 
-@router.get("/activity-ping", dependencies=[get_rate_limit])
+@router.get("/activity-ping")
 def activity_ping(
     current_user: Annotated[User, Depends(ensure_email_verified)],
     db: Annotated[Session, Depends(get_db)],

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -19,14 +19,14 @@ from utils.exceptions import Conflict, Forbidden, InternalServerError
 from utils.firebase_auth import ensure_email_verified
 from utils.firebase_storage import delete_all_profile_pictures
 from schemas.user import UserCreate, UserResponse
-from utils.rate_limiters import update_rate_limit, get_rate_limit
+from utils.rate_limiters import sensitive_updates_limiter, get_rate_limiter
 
 logger = logging.getLogger("meteormate." + __name__)
 
 router = APIRouter()
 
 
-@router.post("/register", response_model=UserResponse, dependencies=[update_rate_limit])
+@router.post("/register", response_model=UserResponse, dependencies=[sensitive_updates_limiter])
 async def register_user(user_data: UserCreate, db: Annotated[Session, Depends(get_db)]):
     if (
         db.query(User).filter((User.utd_id == user_data.net_id)
@@ -69,7 +69,7 @@ async def register_user(user_data: UserCreate, db: Annotated[Session, Depends(ge
         raise  # re-raise the original exception
 
 
-@router.get("/me", response_model=UserResponse, dependencies=[get_rate_limit])
+@router.get("/me", response_model=UserResponse, dependencies=[get_rate_limiter])
 async def get_current_user_profile(current_user: Annotated[User, Depends(ensure_email_verified)], ):
     logger.info(f"User {current_user.id} requested /me")
 
@@ -77,7 +77,7 @@ async def get_current_user_profile(current_user: Annotated[User, Depends(ensure_
 
 
 # more reason to hate YAPF
-@router.delete("/delete", dependencies=[update_rate_limit])
+@router.delete("/delete", dependencies=[sensitive_updates_limiter])
 async def delete_user_account(
     current_user: Annotated[User, Depends(ensure_email_verified)],
     db: Annotated[Session, Depends(get_db)],
@@ -135,7 +135,7 @@ def activity_ping(
     return {"status": "ok"}
 
 
-@router.post("/mark-inactive", dependencies=[update_rate_limit])
+@router.post("/mark-inactive", dependencies=[sensitive_updates_limiter])
 def mark_inactive(
     current_user: Annotated[User, Depends(ensure_email_verified)],
     db: Annotated[Session, Depends(get_db)],

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -7,8 +7,6 @@ from datetime import datetime, timezone
 from typing import Annotated
 
 from fastapi import APIRouter, Depends
-from pyrate_limiter import Duration, Limiter, Rate
-from fastapi_limiter.depends import RateLimiter
 from sqlalchemy.orm import Session
 from firebase_admin import auth
 from firebase_admin.exceptions import FirebaseError
@@ -21,16 +19,11 @@ from utils.exceptions import Conflict, Forbidden, InternalServerError
 from utils.firebase_auth import ensure_email_verified
 from utils.firebase_storage import delete_all_profile_pictures
 from schemas.user import UserCreate, UserResponse
+from utils.rate_limiters import update_rate_limit, get_rate_limit
 
 logger = logging.getLogger("meteormate." + __name__)
 
 router = APIRouter()
-
-update_limiter = Limiter(Rate(1, Duration.MINUTE * 2)) # 1 request every 2 minutes for any update or create survey endpoint
-get_limiter = Limiter(Rate(10, Duration.MINUTE)) # 10 requests per minute for the get survey endpoint
-
-update_rate_limit = Depends(RateLimiter(update_limiter))
-get_rate_limit = Depends(RateLimiter(get_limiter))
 
 
 @router.post("/register", response_model=UserResponse, dependencies=[update_rate_limit])

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -7,6 +7,8 @@ from datetime import datetime, timezone
 from typing import Annotated
 
 from fastapi import APIRouter, Depends
+from pyrate_limiter import Duration, Limiter, Rate
+from fastapi_limiter.depends import RateLimiter
 from sqlalchemy.orm import Session
 from firebase_admin import auth
 from firebase_admin.exceptions import FirebaseError
@@ -24,8 +26,14 @@ logger = logging.getLogger("meteormate." + __name__)
 
 router = APIRouter()
 
+update_limiter = Limiter(Rate(1, Duration.MINUTE * 2)) # 1 request every 2 minutes for any update or create survey endpoint
+get_limiter = Limiter(Rate(10, Duration.MINUTE)) # 10 requests per minute for the get survey endpoint
 
-@router.post("/register", response_model=UserResponse)
+update_rate_limit = Depends(RateLimiter(update_limiter))
+get_rate_limit = Depends(RateLimiter(get_limiter))
+
+
+@router.post("/register", response_model=UserResponse, dependencies=[update_rate_limit])
 async def register_user(user_data: UserCreate, db: Annotated[Session, Depends(get_db)]):
     if (
         db.query(User).filter((User.utd_id == user_data.net_id)
@@ -68,7 +76,7 @@ async def register_user(user_data: UserCreate, db: Annotated[Session, Depends(ge
         raise  # re-raise the original exception
 
 
-@router.get("/me", response_model=UserResponse)
+@router.get("/me", response_model=UserResponse, dependencies=[get_rate_limit])
 async def get_current_user_profile(current_user: Annotated[User, Depends(ensure_email_verified)], ):
     logger.info(f"User {current_user.id} requested /me")
 
@@ -76,7 +84,7 @@ async def get_current_user_profile(current_user: Annotated[User, Depends(ensure_
 
 
 # more reason to hate YAPF
-@router.delete("/delete")
+@router.delete("/delete", dependencies=[update_rate_limit])
 async def delete_user_account(
     current_user: Annotated[User, Depends(ensure_email_verified)],
     db: Annotated[Session, Depends(get_db)],
@@ -121,7 +129,7 @@ async def delete_user_account(
     return {"message": "Account deleted successfully"}
 
 
-@router.get("/activity-ping")
+@router.get("/activity-ping", dependencies=[get_rate_limit])
 def activity_ping(
     current_user: Annotated[User, Depends(ensure_email_verified)],
     db: Annotated[Session, Depends(get_db)],
@@ -134,7 +142,7 @@ def activity_ping(
     return {"status": "ok"}
 
 
-@router.post("/mark-inactive")
+@router.post("/mark-inactive", dependencies=[update_rate_limit])
 def mark_inactive(
     current_user: Annotated[User, Depends(ensure_email_verified)],
     db: Annotated[Session, Depends(get_db)],

--- a/routes/profiles.py
+++ b/routes/profiles.py
@@ -7,6 +7,8 @@ from urllib.parse import unquote, urlparse
 import uuid
 
 from fastapi import APIRouter, Depends
+from pyrate_limiter import Duration, Limiter, Rate
+from fastapi_limiter.depends import RateLimiter
 from sqlalchemy.orm import Session
 
 from models.admin import Banlist
@@ -29,8 +31,14 @@ logger = logging.getLogger("meteormate." + __name__)
 
 router = APIRouter()
 
+update_limiter = Limiter(Rate(1, Duration.MINUTE * 2)) # 1 request every 2 minutes for any update or create profile endpoint
+get_limiter = Limiter(Rate(10, Duration.MINUTE)) # 10 requests per minute for the get profile endpoint
 
-@router.post("/create", response_model=UserProfileResponse)
+update_rate_limit = Depends(RateLimiter(update_limiter))
+get_rate_limit = Depends(RateLimiter(get_limiter))
+
+
+@router.post("/create", response_model=UserProfileResponse, dependencies=[update_rate_limit])
 async def create_user_profile(
     profile_data: UserProfileCreate,
     current_user: Annotated[User, Depends(ensure_email_verified)],
@@ -49,7 +57,7 @@ async def create_user_profile(
     return profile
 
 
-@router.put("/update", response_model=UserProfileResponse)
+@router.put("/update", response_model=UserProfileResponse, dependencies=[update_rate_limit])
 async def update_user_profile(
     profile_data: UserProfileUpdate,
     current_user: Annotated[User, Depends(ensure_email_verified)],
@@ -71,7 +79,7 @@ async def update_user_profile(
     return profile
 
 
-@router.get("/get/{uid}", response_model=UserProfileResponse)
+@router.get("/get/{uid}", response_model=UserProfileResponse, dependencies=[get_rate_limit])
 async def get_user_profile(uid: str, db: Annotated[Session, Depends(get_db)]):
     profile = db.query(UserProfile).filter(UserProfile.user_id == uid).first()
     if not profile:
@@ -87,7 +95,7 @@ async def get_user_profile(uid: str, db: Annotated[Session, Depends(get_db)]):
     return profile
 
 
-@router.post("/upload_picture", response_model=UserProfileResponse)
+@router.post("/upload_picture", response_model=UserProfileResponse, dependencies=[update_rate_limit])
 async def upload_profile_pic(
     image_data: UserProfilePicture,
     current_user: Annotated[User, Depends(ensure_email_verified)],
@@ -117,7 +125,7 @@ async def upload_profile_pic(
     return profile
 
 
-@router.delete("/delete_picture/{index}", response_model=UserProfileResponse)
+@router.delete("/delete_picture/{index}", response_model=UserProfileResponse, dependencies=[update_rate_limit])
 async def delete_profile_pic(
     index: int,
     current_user: Annotated[User, Depends(ensure_email_verified)],
@@ -152,7 +160,7 @@ async def delete_profile_pic(
     return profile
 
 
-@router.post("/update_notifications", response_model=UserProfileResponse)
+@router.post("/update_notifications", response_model=UserProfileResponse, dependencies=[update_rate_limit])
 async def update_notifications(
     notification_updates: UserUpdateNotifications,
     current_user: Annotated[User, Depends(ensure_email_verified)],

--- a/routes/profiles.py
+++ b/routes/profiles.py
@@ -7,9 +7,9 @@ from urllib.parse import unquote, urlparse
 import uuid
 
 from fastapi import APIRouter, Depends
-from pyrate_limiter import Duration, Limiter, Rate
-from fastapi_limiter.depends import RateLimiter
 from sqlalchemy.orm import Session
+from urllib.parse import unquote, urlparse
+import uuid
 
 from models.admin import Banlist
 from models.user import User
@@ -26,16 +26,11 @@ from schemas.user_profile import (
     UserUpdateNotifications,
 )
 from utils.firebase_auth import ensure_email_verified
+from utils.rate_limiters import update_rate_limit, get_rate_limit
 
 logger = logging.getLogger("meteormate." + __name__)
 
 router = APIRouter()
-
-update_limiter = Limiter(Rate(1, Duration.MINUTE * 2)) # 1 request every 2 minutes for any update or create profile endpoint
-get_limiter = Limiter(Rate(10, Duration.MINUTE)) # 10 requests per minute for the get profile endpoint
-
-update_rate_limit = Depends(RateLimiter(update_limiter))
-get_rate_limit = Depends(RateLimiter(get_limiter))
 
 
 @router.post("/create", response_model=UserProfileResponse, dependencies=[update_rate_limit])

--- a/routes/profiles.py
+++ b/routes/profiles.py
@@ -26,14 +26,14 @@ from schemas.user_profile import (
     UserUpdateNotifications,
 )
 from utils.firebase_auth import ensure_email_verified
-from utils.rate_limiters import update_rate_limit, get_rate_limit
+from utils.rate_limiters import sensitive_updates_limiter, regular_updates_limiter, get_rate_limiter
 
 logger = logging.getLogger("meteormate." + __name__)
 
 router = APIRouter()
 
 
-@router.post("/create", response_model=UserProfileResponse, dependencies=[update_rate_limit])
+@router.post("/create", response_model=UserProfileResponse, dependencies=[sensitive_updates_limiter])
 async def create_user_profile(
     profile_data: UserProfileCreate,
     current_user: Annotated[User, Depends(ensure_email_verified)],
@@ -52,7 +52,7 @@ async def create_user_profile(
     return profile
 
 
-@router.put("/update", response_model=UserProfileResponse, dependencies=[update_rate_limit])
+@router.put("/update", response_model=UserProfileResponse, dependencies=[regular_updates_limiter])
 async def update_user_profile(
     profile_data: UserProfileUpdate,
     current_user: Annotated[User, Depends(ensure_email_verified)],
@@ -74,7 +74,7 @@ async def update_user_profile(
     return profile
 
 
-@router.get("/get/{uid}", response_model=UserProfileResponse, dependencies=[get_rate_limit])
+@router.get("/get/{uid}", response_model=UserProfileResponse, dependencies=[get_rate_limiter])
 async def get_user_profile(uid: str, db: Annotated[Session, Depends(get_db)]):
     profile = db.query(UserProfile).filter(UserProfile.user_id == uid).first()
     if not profile:
@@ -90,7 +90,7 @@ async def get_user_profile(uid: str, db: Annotated[Session, Depends(get_db)]):
     return profile
 
 
-@router.post("/upload_picture", response_model=UserProfileResponse, dependencies=[update_rate_limit])
+@router.post("/upload_picture", response_model=UserProfileResponse, dependencies=[sensitive_updates_limiter])
 async def upload_profile_pic(
     image_data: UserProfilePicture,
     current_user: Annotated[User, Depends(ensure_email_verified)],
@@ -120,7 +120,7 @@ async def upload_profile_pic(
     return profile
 
 
-@router.delete("/delete_picture/{index}", response_model=UserProfileResponse, dependencies=[update_rate_limit])
+@router.delete("/delete_picture/{index}", response_model=UserProfileResponse, dependencies=[regular_updates_limiter])
 async def delete_profile_pic(
     index: int,
     current_user: Annotated[User, Depends(ensure_email_verified)],
@@ -155,7 +155,7 @@ async def delete_profile_pic(
     return profile
 
 
-@router.post("/update_notifications", response_model=UserProfileResponse, dependencies=[update_rate_limit])
+@router.post("/update_notifications", response_model=UserProfileResponse, dependencies=[regular_updates_limiter])
 async def update_notifications(
     notification_updates: UserUpdateNotifications,
     current_user: Annotated[User, Depends(ensure_email_verified)],

--- a/routes/survey.py
+++ b/routes/survey.py
@@ -20,13 +20,13 @@ from utils.firebase_auth import ensure_email_verified
 logger = logging.getLogger("meteormate." + __name__)
 router = APIRouter()
 
-post_limiter = Limiter(Rate(1, Duration.MINUTE * 2)) # 1 request every 2 minutes for any update or create survey endpoint
+update_limiter = Limiter(Rate(1, Duration.MINUTE * 2)) # 1 request every 2 minutes for any update or create survey endpoint
 get_limiter = Limiter(Rate(10, Duration.MINUTE)) # 10 requests per minute for the get survey endpoint
 
-post_rate_limit = Depends(RateLimiter(post_limiter))
+update_rate_limit = Depends(RateLimiter(update_limiter))
 get_rate_limit = Depends(RateLimiter(get_limiter))
 
-@router.post("", response_model=SurveyResponse, dependencies=[post_rate_limit])
+@router.post("", response_model=SurveyResponse, dependencies=[update_rate_limit])
 async def create_survey(
     survey_data: SurveyCreate,
     current_user: Annotated[User, Depends(ensure_email_verified)],
@@ -60,7 +60,7 @@ async def get_my_survey(current_user: Annotated[User, Depends(ensure_email_verif
     return current_user.survey
 
 
-@router.put("", response_model=SurveyResponse, dependencies=[post_rate_limit])
+@router.put("", response_model=SurveyResponse, dependencies=[update_rate_limit])
 async def update_survey(
     survey_data: SurveyUpdate,
     current_user: Annotated[User, Depends(ensure_email_verified)],

--- a/routes/survey.py
+++ b/routes/survey.py
@@ -6,8 +6,6 @@ import logging
 from typing import Annotated
 
 from fastapi import APIRouter, Depends
-from pyrate_limiter import Duration, Limiter, Rate
-from fastapi_limiter.depends import RateLimiter
 from sqlalchemy.orm import Session
 
 from database import commit_or_raise, get_db
@@ -16,15 +14,10 @@ from models.survey import Survey
 from models.user import User
 from schemas.survey import SurveyCreate, SurveyResponse, SurveyUpdate
 from utils.firebase_auth import ensure_email_verified
+from utils.rate_limiters import update_rate_limit, get_rate_limit
 
 logger = logging.getLogger("meteormate." + __name__)
 router = APIRouter()
-
-update_limiter = Limiter(Rate(1, Duration.MINUTE * 2)) # 1 request every 2 minutes for any update or create survey endpoint
-get_limiter = Limiter(Rate(10, Duration.MINUTE)) # 10 requests per minute for the get survey endpoint
-
-update_rate_limit = Depends(RateLimiter(update_limiter))
-get_rate_limit = Depends(RateLimiter(get_limiter))
 
 @router.post("", response_model=SurveyResponse, dependencies=[update_rate_limit])
 async def create_survey(

--- a/routes/survey.py
+++ b/routes/survey.py
@@ -14,12 +14,12 @@ from models.survey import Survey
 from models.user import User
 from schemas.survey import SurveyCreate, SurveyResponse, SurveyUpdate
 from utils.firebase_auth import ensure_email_verified
-from utils.rate_limiters import update_rate_limit, get_rate_limit
+from utils.rate_limiters import sensitive_updates_limiter, regular_updates_limiter, get_rate_limiter
 
 logger = logging.getLogger("meteormate." + __name__)
 router = APIRouter()
 
-@router.post("", response_model=SurveyResponse, dependencies=[update_rate_limit])
+@router.post("", response_model=SurveyResponse, dependencies=[sensitive_updates_limiter])
 async def create_survey(
     survey_data: SurveyCreate,
     current_user: Annotated[User, Depends(ensure_email_verified)],
@@ -41,7 +41,7 @@ async def create_survey(
     return survey
 
 
-@router.get("/me", response_model=SurveyResponse, dependencies=[get_rate_limit])
+@router.get("/me", response_model=SurveyResponse, dependencies=[get_rate_limiter])
 async def get_my_survey(current_user: Annotated[User, Depends(ensure_email_verified)]):
     uid = current_user.id
 
@@ -53,7 +53,7 @@ async def get_my_survey(current_user: Annotated[User, Depends(ensure_email_verif
     return current_user.survey
 
 
-@router.put("", response_model=SurveyResponse, dependencies=[update_rate_limit])
+@router.put("", response_model=SurveyResponse, dependencies=[regular_updates_limiter])
 async def update_survey(
     survey_data: SurveyUpdate,
     current_user: Annotated[User, Depends(ensure_email_verified)],

--- a/routes/survey.py
+++ b/routes/survey.py
@@ -6,6 +6,8 @@ import logging
 from typing import Annotated
 
 from fastapi import APIRouter, Depends
+from pyrate_limiter import Duration, Limiter, Rate
+from fastapi_limiter.depends import RateLimiter
 from sqlalchemy.orm import Session
 
 from database import commit_or_raise, get_db
@@ -18,8 +20,13 @@ from utils.firebase_auth import ensure_email_verified
 logger = logging.getLogger("meteormate." + __name__)
 router = APIRouter()
 
+post_limiter = Limiter(Rate(1, Duration.MINUTE * 2)) # 1 request every 2 minutes for any update or create survey endpoint
+get_limiter = Limiter(Rate(10, Duration.MINUTE)) # 10 requests per minute for the get survey endpoint
 
-@router.post("", response_model=SurveyResponse)
+post_rate_limit = Depends(RateLimiter(post_limiter))
+get_rate_limit = Depends(RateLimiter(get_limiter))
+
+@router.post("", response_model=SurveyResponse, dependencies=[post_rate_limit])
 async def create_survey(
     survey_data: SurveyCreate,
     current_user: Annotated[User, Depends(ensure_email_verified)],
@@ -41,7 +48,7 @@ async def create_survey(
     return survey
 
 
-@router.get("/me", response_model=SurveyResponse)
+@router.get("/me", response_model=SurveyResponse, dependencies=[get_rate_limit])
 async def get_my_survey(current_user: Annotated[User, Depends(ensure_email_verified)]):
     uid = current_user.id
 
@@ -53,7 +60,7 @@ async def get_my_survey(current_user: Annotated[User, Depends(ensure_email_verif
     return current_user.survey
 
 
-@router.put("", response_model=SurveyResponse)
+@router.put("", response_model=SurveyResponse, dependencies=[post_rate_limit])
 async def update_survey(
     survey_data: SurveyUpdate,
     current_user: Annotated[User, Depends(ensure_email_verified)],

--- a/routes/verification.py
+++ b/routes/verification.py
@@ -29,10 +29,10 @@ logger = logging.getLogger("meteormate." + __name__)
 
 limiter = Limiter(Rate(1, Duration.MINUTE)) # 1 request per minute for all endpoints in this router
 rate_limit = Depends(RateLimiter(limiter))
-router = APIRouter()
+router = APIRouter(dependencies=[rate_limit])
 
 
-@router.get("/account_verification", dependencies=[rate_limit])
+@router.get("/account_verification")
 def send_account_verification_email(
     current_user: Annotated[User, Depends(get_current_user)],
     db: Annotated[Session, Depends(get_db)],
@@ -64,7 +64,7 @@ def send_account_verification_email(
         raise InternalServerError("Failed to send verification code")
 
 
-@router.post("/account_verification", dependencies=[rate_limit])
+@router.post("/account_verification")
 def account_verification(
     code_data: UserVerifyEmail,
     current_user: Annotated[User, Depends(get_current_user)],
@@ -89,7 +89,7 @@ def account_verification(
     return {"message": "Email verified successfully"}
 
 
-@router.get("/reset_password/{email}", dependencies=[rate_limit])
+@router.get("/reset_password/{email}")
 def send_reset_password_email(
     email: str,
     db: Annotated[Session, Depends(get_db)],
@@ -119,7 +119,7 @@ def send_reset_password_email(
         raise InternalServerError("Failed to send verification code")
 
 
-@router.post("/reset_password", dependencies=[rate_limit])
+@router.post("/reset_password")
 def reset_password(
     request: UserResetPassword,
     db: Annotated[Session, Depends(get_db)],
@@ -136,8 +136,8 @@ def reset_password(
     next(verify_gen)
 
     # lil troll hehe
-    # if request.new_password:
-    #     raise BadRequest("Password cannot be the same as old password")
+    if request.new_password:
+        raise BadRequest("Password cannot be the same as old password")
 
     try:
         auth.update_user(uid, password=request.new_password)

--- a/routes/verification.py
+++ b/routes/verification.py
@@ -5,6 +5,8 @@ import logging
 from typing import Annotated
 
 from fastapi import APIRouter, Depends
+from pyrate_limiter import Duration, Limiter, Rate
+from fastapi_limiter.depends import RateLimiter
 from sqlalchemy.orm import Session
 from firebase_admin import auth
 from firebase_admin.exceptions import FirebaseError
@@ -25,10 +27,12 @@ from utils.verification_codes import create_verification_code, verify_code
 
 logger = logging.getLogger("meteormate." + __name__)
 
+limiter = Limiter(Rate(1, Duration.MINUTE)) # 1 request per minute for all endpoints in this router
+rate_limit = Depends(RateLimiter(limiter))
 router = APIRouter()
 
 
-@router.get("/account_verification")
+@router.get("/account_verification", dependencies=[rate_limit])
 def send_account_verification_email(
     current_user: Annotated[User, Depends(get_current_user)],
     db: Annotated[Session, Depends(get_db)],
@@ -60,7 +64,7 @@ def send_account_verification_email(
         raise InternalServerError("Failed to send verification code")
 
 
-@router.post("/account_verification")
+@router.post("/account_verification", dependencies=[rate_limit])
 def account_verification(
     code_data: UserVerifyEmail,
     current_user: Annotated[User, Depends(get_current_user)],
@@ -85,7 +89,7 @@ def account_verification(
     return {"message": "Email verified successfully"}
 
 
-@router.get("/reset_password/{email}")
+@router.get("/reset_password/{email}", dependencies=[rate_limit])
 def send_reset_password_email(
     email: str,
     db: Annotated[Session, Depends(get_db)],
@@ -115,7 +119,7 @@ def send_reset_password_email(
         raise InternalServerError("Failed to send verification code")
 
 
-@router.post("/reset_password")
+@router.post("/reset_password", dependencies=[rate_limit])
 def reset_password(
     request: UserResetPassword,
     db: Annotated[Session, Depends(get_db)],
@@ -132,8 +136,8 @@ def reset_password(
     next(verify_gen)
 
     # lil troll hehe
-    if request.new_password:
-        raise BadRequest("Password cannot be the same as old password")
+    # if request.new_password:
+    #     raise BadRequest("Password cannot be the same as old password")
 
     try:
         auth.update_user(uid, password=request.new_password)

--- a/utils/rate_limiters.py
+++ b/utils/rate_limiters.py
@@ -1,0 +1,13 @@
+# Created by Atharva Mishra
+# ACM MeteorMate | All Rights Reserved
+
+from fastapi import Depends
+from pyrate_limiter import Duration, Limiter, Rate
+from fastapi_limiter.depends import RateLimiter
+
+# Survey, Profiles, and Auth Routes
+update_limiter = Limiter(Rate(1, Duration.MINUTE * 2))  # 1 request every 2 minutes for update/create endpoints
+get_limiter = Limiter(Rate(10, Duration.MINUTE))  # 10 requests per minute for get endpoints
+
+update_rate_limit = Depends(RateLimiter(update_limiter))
+get_rate_limit = Depends(RateLimiter(get_limiter))

--- a/utils/rate_limiters.py
+++ b/utils/rate_limiters.py
@@ -6,8 +6,10 @@ from pyrate_limiter import Duration, Limiter, Rate
 from fastapi_limiter.depends import RateLimiter
 
 # Survey, Profiles, and Auth Routes
-update_limiter = Limiter(Rate(1, Duration.MINUTE * 2))  # 1 request every 2 minutes for update/create endpoints
-get_limiter = Limiter(Rate(10, Duration.MINUTE))  # 10 requests per minute for get endpoints
+sensitive_updates_limit = Limiter(Rate(1, Duration.MINUTE * 2))  # 1 request every 2 minutes for sensitive update endpoints
+regular_updates_limit = Limiter(Rate(5, Duration.MINUTE))  # 5 requests per minute for regular update endpoints
+get_limit = Limiter(Rate(10, Duration.MINUTE))  # 10 requests per minute for get endpoints
 
-update_rate_limit = Depends(RateLimiter(update_limiter))
-get_rate_limit = Depends(RateLimiter(get_limiter))
+sensitive_updates_limiter = Depends(RateLimiter(sensitive_updates_limit))
+regular_updates_limiter = Depends(RateLimiter(regular_updates_limit))
+get_rate_limiter = Depends(RateLimiter(get_limit))


### PR DESCRIPTION
# Changes
- Added rate limiting on survey, profile, and auth routes
    - Routes that involve creating, deleting, or updating records in the DB are limited to 1 per 2 minutes
    - Routes that involve simple GET requests from the DB are limited to 10 per limit
- Added rate limiting on verification codes routes that if fully limited to 1 a minute for spam prevention

Here is what I looks like:
<img width="1353" height="327" alt="image" src="https://github.com/user-attachments/assets/78168175-e076-41d5-b846-d20ac2d3b24d" />

It let 10 through, but stopped the 11th on the GET endpoint for profiles, it even shows the IP of the request, which I don't know if its new or it got added by the rate limiter.

Closes #72 and blocks #74 