### PR TITLE
feat: bulk "upload" and deletion of images to bypass rate-limiter

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,6 +1,6 @@
 [style]
 based_on_style = pep8
-column_limit = 100
+column_limit = 150
 spaces_before_comment = 2
 split_before_logical_operator = true
 dedent_closing_brackets = true

--- a/routes/profiles.py
+++ b/routes/profiles.py
@@ -112,10 +112,6 @@ async def delete_profile_pics(
         raise NotFound("User profile")
 
     for url in pictures_to_delete.profile_picture_url:
-        if url not in profile.profile_picture_url:
-            logger.warning(f"User {uid} attempted to delete a picture that is not in their profile")
-            raise BadRequest("One or more provided picture URLs are not in the user's profile")
-
         # this basically parses the url to recognize any params with '?' and any url encodings
         parsed_url = urlparse(url)
         url_path = unquote(parsed_url.path)  # get only the path
@@ -125,7 +121,8 @@ async def delete_profile_pics(
         delete_profile_picture(f"profile_pictures/{uid}/{file_name}")
 
         # Remove the picture URL from the list
-        profile.profile_picture_url.remove(url)
+        if url in profile.profile_picture_url:
+            profile.profile_picture_url.remove(url)
 
     commit_or_raise(db, logger, resource="user profile", uid=uid, action="delete pictures")
 

--- a/routes/profiles.py
+++ b/routes/profiles.py
@@ -110,7 +110,7 @@ async def delete_profile_pics(
     if not profile:
         logger.warning(f"profile not found for User {uid}")
         raise NotFound("User profile")
-
+    
     for url in pictures_to_delete.profile_picture_url:
         # this basically parses the url to recognize any params with '?' and any url encodings
         parsed_url = urlparse(url)
@@ -122,7 +122,9 @@ async def delete_profile_pics(
 
         # Remove the picture URL from the list
         if url in profile.profile_picture_url:
-            profile.profile_picture_url.remove(url)
+            for i in range(len(profile.profile_picture_url)):
+                if profile.profile_picture_url[i] == url:
+                    profile.profile_picture_url[i] = "" # set to empty string instead of removing to maintain list length of 5
 
     commit_or_raise(db, logger, resource="user profile", uid=uid, action="delete pictures")
 

--- a/routes/profiles.py
+++ b/routes/profiles.py
@@ -4,36 +4,30 @@
 import logging
 from typing import Annotated
 from urllib.parse import unquote, urlparse
-import uuid
 
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
-from urllib.parse import unquote, urlparse
-import uuid
-
-from models.admin import Banlist
-from models.user import User
-from utils.exceptions import BadRequest, Conflict, Forbidden, NotFound
-from utils.firebase_storage import upload_profile_picture, delete_profile_picture
 
 from database import commit_or_raise, get_db
+from models.admin import Banlist
+from models.user import User
 from models.user_profile import UserProfile
-from schemas.user_profile import (
-    UserProfileCreate,
-    UserProfilePicture,
-    UserProfileResponse,
-    UserProfileUpdate,
-    UserUpdateNotifications,
-)
+from schemas.user_profile import UserProfileCreate, UserProfileDeletePictures, UserProfileResponse, UserProfileUpdate, UserUpdateNotifications
+from utils.exceptions import BadRequest, Conflict, Forbidden, NotFound
 from utils.firebase_auth import ensure_email_verified
-from utils.rate_limiters import sensitive_updates_limiter, regular_updates_limiter, get_rate_limiter
+from utils.firebase_storage import delete_profile_picture
+from utils.rate_limiters import get_rate_limiter, regular_updates_limiter, sensitive_updates_limiter
 
 logger = logging.getLogger("meteormate." + __name__)
 
 router = APIRouter()
 
 
-@router.post("/create", response_model=UserProfileResponse, dependencies=[sensitive_updates_limiter])
+@router.post(
+    "/create",
+    response_model=UserProfileResponse,
+    dependencies=[sensitive_updates_limiter],
+)
 async def create_user_profile(
     profile_data: UserProfileCreate,
     current_user: Annotated[User, Depends(ensure_email_verified)],
@@ -42,6 +36,10 @@ async def create_user_profile(
     if current_user.profile:
         logger.warning(f"profile already exists for User {current_user.id}")
         raise Conflict("User profile already exists")
+
+    if len(profile_data.profile_picture_url) != 5:
+        logger.warning(f"User {current_user.id} attempted to upload an incorrect number of profile pictures")
+        raise BadRequest("Exactly 5 profile pictures must be uploaded")
 
     profile = UserProfile(user_id=current_user.id, **profile_data.model_dump())
     db.add(profile)
@@ -52,7 +50,11 @@ async def create_user_profile(
     return profile
 
 
-@router.put("/update", response_model=UserProfileResponse, dependencies=[regular_updates_limiter])
+@router.put(
+    "/update",
+    response_model=UserProfileResponse,
+    dependencies=[regular_updates_limiter],
+)
 async def update_user_profile(
     profile_data: UserProfileUpdate,
     current_user: Annotated[User, Depends(ensure_email_verified)],
@@ -63,6 +65,10 @@ async def update_user_profile(
     if not profile:
         logger.warning(f"profile not found for User {current_user.id}")
         raise NotFound("User profile")
+
+    if profile_data.profile_picture_url is not None and len(profile_data.profile_picture_url) != 5:
+        logger.warning(f"User {current_user.id} attempted to upload an incorrect number of profile pictures")
+        raise BadRequest("Exactly 5 profile pictures must be uploaded")
 
     update_data = profile_data.model_dump(exclude_unset=True)
     for field, value in update_data.items():
@@ -83,46 +89,18 @@ async def get_user_profile(uid: str, db: Annotated[Session, Depends(get_db)]):
 
     if db.query(Banlist).filter(Banlist.net_id == uid).first():
         logger.warning(f"User with Net ID {uid} attempted to access profile but is banned")
-        raise Forbidden(
-            "This user is banned from using this service. If you believe this is a mistake, please contact support."
-        )
+        raise Forbidden("This user is banned from using this service. If you believe this is a mistake, please contact support.")
 
     return profile
 
 
-@router.post("/upload_picture", response_model=UserProfileResponse, dependencies=[sensitive_updates_limiter])
-async def upload_profile_pic(
-    image_data: UserProfilePicture,
-    current_user: Annotated[User, Depends(ensure_email_verified)],
-    db: Annotated[Session, Depends(get_db)],
-):
-    profile = current_user.profile
-    uid = current_user.id
-
-    if not profile:
-        logger.warning(f"profile not found for User {uid}")
-        raise NotFound("User profile")
-
-    if profile.profile_picture_url is None:
-        profile.profile_picture_url = []
-
-    img_id = str(uuid.uuid4())
-    blob_path = f"profile_pictures/{uid}/{img_id}.webp"
-
-    # raises http exceptions do not catch
-    profile_pic_url = upload_profile_picture(image_data.image_bytes, blob_path)
-    profile.profile_picture_url.append(profile_pic_url)
-
-    commit_or_raise(db, logger, resource="user profile", uid=uid, action="upload")
-
-    db.refresh(profile)
-
-    return profile
-
-
-@router.delete("/delete_picture/{index}", response_model=UserProfileResponse, dependencies=[regular_updates_limiter])
-async def delete_profile_pic(
-    index: int,
+@router.delete(
+    "/delete_pictures",
+    response_model=UserProfileResponse,
+    dependencies=[regular_updates_limiter],
+)
+async def delete_profile_pics(
+    pictures_to_delete: UserProfileDeletePictures,
     current_user: Annotated[User, Depends(ensure_email_verified)],
     db: Annotated[Session, Depends(get_db)],
 ):
@@ -133,29 +111,34 @@ async def delete_profile_pic(
         logger.warning(f"profile not found for User {uid}")
         raise NotFound("User profile")
 
-    if index < 0 or index >= len(profile.profile_picture_url):
-        logger.warning(f"invalid picture index {index} for User {uid}")
-        raise BadRequest("Index out-of-bounds for profile pictures")  # kinda funny ngl
+    for url in pictures_to_delete.profile_picture_url:
+        if url not in profile.profile_picture_url:
+            logger.warning(f"User {uid} attempted to delete a picture that is not in their profile")
+            raise BadRequest("One or more provided picture URLs are not in the user's profile")
 
-    # this basically parses the url to recognize any params with '?' and any url encodings
-    parsed_url = urlparse(profile.profile_picture_url[index])
-    url_path = unquote(parsed_url.path)  # get only the path
-    file_name = url_path.split("/")[-1]
+        # this basically parses the url to recognize any params with '?' and any url encodings
+        parsed_url = urlparse(url)
+        url_path = unquote(parsed_url.path)  # get only the path
+        file_name = url_path.split("/")[-1]
 
-    # firebase storage helper don't confuse with endpoint function (also don't catch exceptions from this)
-    delete_profile_picture(f"profile_pictures/{uid}/{file_name}")
+        # firebase storage helper don't confuse with endpoint function (also don't catch exceptions from this)
+        delete_profile_picture(f"profile_pictures/{uid}/{file_name}")
 
-    # Remove the picture URL from the list
-    profile.profile_picture_url.pop(index)
+        # Remove the picture URL from the list
+        profile.profile_picture_url.remove(url)
 
-    commit_or_raise(db, logger, resource="user profile", uid=uid, action="delete")
+    commit_or_raise(db, logger, resource="user profile", uid=uid, action="delete pictures")
 
     db.refresh(profile)
 
     return profile
 
 
-@router.post("/update_notifications", response_model=UserProfileResponse, dependencies=[regular_updates_limiter])
+@router.post(
+    "/update_notifications",
+    response_model=UserProfileResponse,
+    dependencies=[regular_updates_limiter],
+)
 async def update_notifications(
     notification_updates: UserUpdateNotifications,
     current_user: Annotated[User, Depends(ensure_email_verified)],

--- a/routes/profiles.py
+++ b/routes/profiles.py
@@ -117,11 +117,11 @@ async def delete_profile_pics(
         url_path = unquote(parsed_url.path)  # get only the path
         file_name = url_path.split("/")[-1]
 
-        # firebase storage helper don't confuse with endpoint function (also don't catch exceptions from this)
-        delete_profile_picture(f"profile_pictures/{uid}/{file_name}")
-
         # Remove the picture URL from the list
         if url in profile.profile_picture_url:
+            # firebase storage helper don't confuse with endpoint function (also don't catch exceptions from this)
+            delete_profile_picture(f"profile_pictures/{uid}/{file_name}")
+            
             for i in range(len(profile.profile_picture_url)):
                 if profile.profile_picture_url[i] == url:
                     profile.profile_picture_url[i] = "" # set to empty string instead of removing to maintain list length of 5

--- a/schemas/user_profile.py
+++ b/schemas/user_profile.py
@@ -2,14 +2,12 @@
 # Updated by Atharva Mishra
 # ACM MeteorMate | All Rights Reserved
 
-import base64
-import binascii
 from typing import List, Optional, Literal
 from datetime import datetime
 from pydantic import BaseModel, field_validator, model_validator
 
 from config import settings
-from utils.exceptions import BadRequest, UnprocessableEntity
+from utils.exceptions import BadRequest
 
 Gender = Literal["female", "male", "non_binary", "prefer_not_to_say", "other"]
 Classification = Literal["freshman", "sophomore", "junior", "senior", "graduate"]
@@ -17,14 +15,10 @@ Classification = Literal["freshman", "sophomore", "junior", "senior", "graduate"
 
 def validate_name(name: str, min_len: int, max_len: int, position: str) -> str:
     if not (min_len <= len(name) <= max_len):
-        raise BadRequest(
-            f"{position} name must be between {min_len} and {max_len} characters"
-        )
+        raise BadRequest(f"{position} name must be between {min_len} and {max_len} characters")
 
     if not name.isalpha():
-        raise BadRequest(
-            f"{position} name cannot contain any numbers or special characters"
-        )
+        raise BadRequest(f"{position} name cannot contain any numbers or special characters")
 
     return name
 
@@ -51,9 +45,7 @@ class UserProfileBase(BaseModel):
         if v is None:
             return v
 
-        return validate_name(
-            v, settings.FIRST_NAME_MIN_LEN, settings.FIRST_NAME_MAX_LEN, "first"
-        )
+        return validate_name(v, settings.FIRST_NAME_MIN_LEN, settings.FIRST_NAME_MAX_LEN, "first")
 
     @field_validator("last_name")
     @classmethod
@@ -61,9 +53,7 @@ class UserProfileBase(BaseModel):
         if v is None:
             return v
 
-        return validate_name(
-            v, settings.LAST_NAME_MIN_LEN, settings.LAST_NAME_MAX_LEN, "last"
-        )
+        return validate_name(v, settings.LAST_NAME_MIN_LEN, settings.LAST_NAME_MAX_LEN, "last")
 
     @field_validator("dob")
     @classmethod
@@ -81,7 +71,7 @@ class UserProfileBase(BaseModel):
     def calculate_and_validate_age(cls, values):
         if values.age is not None:
             raise BadRequest("Age cannot be provided directly")
-        
+
         dob = values.dob
         if dob is None:
             return values
@@ -89,14 +79,11 @@ class UserProfileBase(BaseModel):
         today = datetime.now()
         age = today.year - dob.year - ((today.month, today.day) < (dob.month, dob.day))
         if not (settings.MIN_AGE <= age <= settings.MAX_AGE):
-            raise BadRequest(
-                f"Age must be between {settings.MIN_AGE} and {settings.MAX_AGE} years"
-            )
-        
+            raise BadRequest(f"Age must be between {settings.MIN_AGE} and {settings.MAX_AGE} years")
+
         values.age = age
 
         return values
-
 
 
 class UserProfileCreate(UserProfileBase):
@@ -134,39 +121,18 @@ class UserProfileResponse(BaseModel):
         from_attributes = True
 
 
-class UserProfilePicture(BaseModel):
-    base64: str
+class UserProfileDeletePictures(BaseModel):
+    profile_picture_url: List[str]
 
-    ext: str
-    image_bytes: bytes
-
-    @model_validator(mode="before")
+    @field_validator("profile_picture_url")
     @classmethod
-    def parse_and_validate(cls, values):
-        raw = values.get("base64")
-        if not raw or "," not in raw:
-            raise UnprocessableEntity("Image data not in base64 format")
+    def validate_picture_count(cls, v):
+        if len(v) == 0:
+            raise BadRequest("At least one profile picture must be provided for deletion")
+        if len(v) > 5:
+            raise BadRequest("No more than 5 profile pictures can be deleted at once")
 
-        header, data = raw.split(",", 1)
-
-        if not header.startswith("data:image/") or ";base64" not in header:
-            raise UnprocessableEntity("Invalid image base64 header")
-
-        ext = header[len("data:image/") : header.index(";base64")]
-        if ext not in {"jpeg", "jpg", "png", "webp"}:
-            raise UnprocessableEntity("Not an acceptable image type")
-
-        try:
-            image_bytes = base64.b64decode(data, validate=True)
-        except (ValueError, binascii.Error):
-            raise UnprocessableEntity(
-                "Image data has incorrect padding or invalid characters"
-            )
-
-        values["ext"] = ext
-        values["image_bytes"] = image_bytes
-
-        return values
+        return v
 
 
 class UserUpdateNotifications(BaseModel):
@@ -176,10 +142,7 @@ class UserUpdateNotifications(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def validate_atleast_one(cls, values):
-        if (
-            values.get("match_notification") is None
-            and values.get("promotional_notification") is None
-        ):
+        if (values.get("match_notification") is None and values.get("promotional_notification") is None):
             raise BadRequest("At least one notification preference must be provided")
 
         return values

--- a/schemas/user_profile.py
+++ b/schemas/user_profile.py
@@ -129,8 +129,6 @@ class UserProfileDeletePictures(BaseModel):
     def validate_picture_count(cls, v):
         if len(v) == 0:
             raise BadRequest("At least one profile picture must be provided for deletion")
-        if len(v) > 5:
-            raise BadRequest("No more than 5 profile pictures can be deleted at once")
 
         return v
 

--- a/utils/firebase_storage.py
+++ b/utils/firebase_storage.py
@@ -1,67 +1,10 @@
 # Created by Atharva Mishra | 1/30/2026
 # ACM MeteorMate | All Rights Reserved
 
-import io
 from firebase_admin import storage
 from google.cloud import exceptions
-from PIL import Image, ImageOps, UnidentifiedImageError
 
-from utils.exceptions import Forbidden, NotFound, UnprocessableEntity
-
-
-# function normalizes color type for the image and converts image bytes to webp bytes
-def process_image(image_bytes: bytes) -> bytes:
-    try:
-        with Image.open(io.BytesIO(image_bytes)) as img:
-            img = ImageOps.exif_transpose(img)
-
-            if img.mode != "RGB":
-                img = img.convert("RGB")
-
-            buffer = io.BytesIO()
-            img.save(buffer, format="WEBP", quality=80, method=6, optimize=True)
-
-            return buffer.getvalue()
-
-    except UnidentifiedImageError:
-        raise UnprocessableEntity("Uploaded file is not a valid image")
-
-    except (OSError, ValueError, RuntimeError) as e:
-        raise UnprocessableEntity(
-            "Failed to process image; the file may be corrupted or unsupported"
-        )
-
-    except MemoryError:
-        raise UnprocessableEntity("Image is too large to process")
-
-
-def upload_profile_picture(data: bytes, blob_path: str) -> str:
-    """
-    Function to upload a profile pic based on its base64 data abd blob path
-    Args:
-        data (bytes): Image data in bytes
-        blob_path (str): Path in firebase storage bucket to upload the image to
-    Returns:
-        str: Public URL of the uploaded image
-    Raises: HTTP Exceptions for either 404 or 403
-    """
-    try:
-        image_bytes = process_image(data)
-
-        bucket = storage.bucket()
-        blob = bucket.blob(blob_path)
-
-        blob.upload_from_string(image_bytes, content_type=f"image/webp")
-
-        blob.make_public()
-
-        return blob.public_url
-
-    except exceptions.NotFound:
-        raise NotFound("Storage bucket")
-
-    except exceptions.Forbidden:
-        raise Forbidden("Access to storage bucket denied")
+from utils.exceptions import Forbidden, NotFound
 
 
 def delete_profile_picture(blob_path: str):


### PR DESCRIPTION
# Changes
- previous feature involved manually converting each image's bytes into base64 and then uploading to storage, if the user uploaded 5 images, it would be 5 calls back to back with base64 data of images, which I think would kill the backend if more than 10 people used it.
- Now we "upload" straight CDN links of the images onto the DB because actual image upload is done directly on the frontend, so image tasks are handled by the user's browser instead, like base64 conversion, webp conversion, metadata removal, and actual upload to Firebase Storage.
- For image deletion, the actual act of deleting is done on the backend, and just as with uploading, the link of the image to be deleted is given to the backend, and via some URL probing, it is deleted from Firebase storage.

# Note
- This cannot be merged until the client's repository branch is completed; otherwise, the dev deployment will break
- We need Firebase rules to make sure that Firebase image CDN links can only be opened by the client website and not regular people for safety purposes.